### PR TITLE
Persist last-selected envelopes and transfer totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# EnvelopeMoney
+
+EnvelopeMoney is an Android envelope-budgeting application focused on monthly budget tracking, transaction history, envelope-to-envelope transfers, and recurring transactions.
+
+## Repository Memory System
+This repository uses a lightweight project memory system so AI-assisted development has stable architectural context, user-flow context, and task history before code changes are made.
+
+## Documentation Index
+- `docs/PROJECT_INDEX.md`
+- `docs/ARCHITECTURE.md`
+- `docs/DATA_SCHEMA.md`
+- `docs/features.md`
+- `docs/user-flows.md`
+- `docs/AI_CHANGE_PROTOCOL.md`
+- `state/TASK_STATE.json`
+- `prompts/codex_rules.md`
+
+## Development Expectations
+- Read the repository memory files before changing code.
+- Verify changes against architecture, feature behavior, and user flows.
+- Add or update tests when behavior changes.
+- Confirm compile/test status before finalizing.
+- Update docs and task state whenever behavior or structure changes.
+- Stage commits locally with a structured message; do not push automatically.
+
+## Visuals
+### Repository Memory Structure
+```text
+EnvelopeMoney/
++-- docs/
++-- state/
++-- prompts/
++-- README.md
++-- app/
+```
+
+### Month Rollover Flow
+```text
+Stored state -> sanitize -> decide target month -> rebuild target month on deep copy -> adopt repaired state
+```
+
+### Test Surface Added
+```text
+MonthRolloverHelperTest
+MonthTrackerTest
+```
+
+## Change Log
+- 2026-03-21: Initialized repository memory system.
+- 2026-03-21: Added `MonthRolloverHelper`, startup rollover sanitization, envelope state repair helpers, and month normalization tests.
+- 2026-03-21: Verification is currently blocked locally because this machine only exposes Java 25 while Gradle 6.7.1 requires an older compatible JDK.

--- a/app/src/main/java/com/example/envelopemoney/Envelope.java
+++ b/app/src/main/java/com/example/envelopemoney/Envelope.java
@@ -90,8 +90,8 @@ public class Envelope {
     public double getOriginalLimit(){ return originalLimit; }
     public Double getManualRemaining() { return manualRemaining; }
     public Boolean hasBaseline() {
-        return Double.isNaN(baselineRemaining);
-        }
+        return Double.isFinite(baselineLimit) && Double.isFinite(baselineRemaining);
+    }
     public MonthData getMonthlyData(String month) {
         if (!monthlyData.containsKey(month)) {
             // Initialize with default values if month doesn't exist
@@ -120,6 +120,10 @@ public class Envelope {
     public void setLimit(double limit) {
         this.limit = limit;
         this.originalLimit = limit;
+    }
+
+    public void setOriginalLimit(double originalLimit) {
+        this.originalLimit = originalLimit;
     }
 
     /**
@@ -234,6 +238,13 @@ public class Envelope {
         return transfers;
     }
 
+    public Map<String, MonthData> getMonthlyDataMap() {
+        if (monthlyData == null) {
+            monthlyData = new HashMap<>();
+        }
+        return monthlyData;
+    }
+
     public void addTransfer(String toEnvelope, double amount) {
         getTransfers().add(new TransferData(toEnvelope, amount));
     }
@@ -336,6 +347,65 @@ public class Envelope {
         currentData.remaining = currentData.limit - spent;
     }
 
+    /**
+     * Repairs nullable collections and non-finite numeric state before month-based logic runs.
+     * This is the defensive entry point used during startup and rollover recovery.
+     */
+    public void sanitizeState(String fallbackMonth) {
+        getTransactions();
+        getTransfers();
+        getMonthlyDataMap();
+
+        if (!Double.isFinite(limit)) {
+            limit = 0d;
+        }
+        if (!Double.isFinite(originalLimit)) {
+            originalLimit = limit;
+        }
+        if (!Double.isFinite(remaining)) {
+            remaining = originalLimit;
+        }
+
+        if (manualRemaining != null && !Double.isFinite(manualRemaining)) {
+            manualRemaining = null;
+        }
+        if (!Double.isFinite(baselineLimit)) {
+            baselineLimit = originalLimit;
+        }
+        if (!Double.isFinite(baselineRemaining)) {
+            baselineRemaining = manualRemaining != null ? manualRemaining : remaining;
+        }
+
+        migrateLegacyTransactions(fallbackMonth);
+    }
+
+    public void replaceMonthData(String month, double monthLimit) {
+        MonthData monthData = new MonthData(safe(monthLimit), safe(monthLimit));
+        getMonthlyDataMap().put(month, monthData);
+        rebuildMonthData(month);
+    }
+
+    public void rebuildMonthData(String month) {
+        MonthData monthData = getMonthlyData(month);
+        if (monthData.transactions == null) {
+            monthData.transactions = new ArrayList<>();
+        } else {
+            monthData.transactions.clear();
+        }
+        if (!Double.isFinite(monthData.limit)) {
+            monthData.limit = safe(originalLimit);
+        }
+
+        double spent = 0d;
+        for (Transaction transaction : getTransactions()) {
+            if (transaction != null && Objects.equals(transaction.getMonth(), month)) {
+                monthData.transactions.add(transaction);
+                spent += safe(transaction.getAmount());
+            }
+        }
+        monthData.remaining = monthData.limit - spent;
+    }
+
     private String getPreviousMonth(String currentMonth) {
         try {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
@@ -394,15 +464,20 @@ public class Envelope {
     // Helper to parse date like "2025-03-01 18:07" -> "2025-03"
     private String parseDateToYearMonth(String dateStr) {
         if (dateStr == null || dateStr.isEmpty()) return null;
-        try {
-            SimpleDateFormat input = new SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault());
-            Date date = input.parse(dateStr);
-            SimpleDateFormat output = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
-            return output.format(date);
-        } catch (ParseException e) {
-            e.printStackTrace();
-            return null;
+        String[] supportedFormats = new String[]{"yyyy-MM-dd HH:mm", "yyyy-MM-dd"};
+        for (String format : supportedFormats) {
+            try {
+                SimpleDateFormat input = new SimpleDateFormat(format, Locale.getDefault());
+                Date date = input.parse(dateStr);
+                if (date == null) {
+                    continue;
+                }
+                SimpleDateFormat output = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
+                return output.format(date);
+            } catch (ParseException ignored) {
+            }
         }
+        return null;
     }
     private double getBaselineRemainingOr(double fallback) {
         return (Double.isNaN(baselineRemaining)) ? fallback : baselineRemaining;

--- a/app/src/main/java/com/example/envelopemoney/MainActivity.java
+++ b/app/src/main/java/com/example/envelopemoney/MainActivity.java
@@ -669,62 +669,84 @@ public class MainActivity extends AppCompatActivity {
         double incomingTransferTotal = 0;
 
         for (Envelope envelope : envelopes) {
-            boolean includeEnvelope = envelope.isSelected();
+            boolean envelopeSelected = envelope.isSelected();
             for (Transaction transaction : envelope.getTransactions()) {
-                if (!includeEnvelope) {
-                    continue;
-                }
                 try {
                     Date txDate = sdf.parse(transaction.getDate());
                     if (txDate == null || txDate.before(startDate) || txDate.after(endDate)) {
                         continue;
                     }
+
+                    String transferId = transaction.getTransferId();
+                    Envelope.TransferData transfer = null;
+                    Envelope ownerEnvelope = null;
+                    Envelope destinationEnvelope = null;
+                    boolean isTransfer = transferId != null && !transferId.isEmpty();
+                    boolean isSourceSide = false;
+                    boolean destinationSelected = false;
+                    boolean ownerSelected = false;
+                    boolean includeTransaction = envelopeSelected;
+
+                    if (isTransfer) {
+                        transfer = findTransferById(transferId);
+                        if (transfer != null && transfer.getToEnvelope() != null && !transfer.getToEnvelope().isEmpty()) {
+                            ownerEnvelope = findTransferOwner(transferId);
+                            destinationEnvelope = findEnvelopeByName(transfer.getToEnvelope());
+                            isSourceSide = ownerEnvelope != null
+                                    && Objects.equals(ownerEnvelope.getName(), transaction.getEnvelopeName());
+                            destinationSelected = destinationEnvelope != null && destinationEnvelope.isSelected();
+                            ownerSelected = ownerEnvelope != null && ownerEnvelope.isSelected();
+                            if (!includeTransaction && showTransfers && (ownerSelected || destinationSelected)) {
+                                includeTransaction = true;
+                            }
+                        }
+                    }
+
+                    if (!includeTransaction) {
+                        continue;
+                    }
+
                     filteredTransactions.add(transaction);
                     grossTotal += transaction.getAmount();
 
-                    String transferId = transaction.getTransferId();
-                    if (transferId != null && !transferId.isEmpty()) {
-                        Envelope.TransferData transfer = findTransferById(transferId);
-                        if (transfer != null && transfer.getToEnvelope() != null && !transfer.getToEnvelope().isEmpty()) {
-                            double amount = Math.abs(transaction.getAmount());
-                            Envelope ownerEnvelope = findTransferOwner(transferId);
-                            boolean isSourceSide = ownerEnvelope != null && Objects.equals(ownerEnvelope.getName(), transaction.getEnvelopeName());
-                            Envelope destinationEnvelope = findEnvelopeByName(transfer.getToEnvelope());
-                            boolean destinationSelected = destinationEnvelope != null && destinationEnvelope.isSelected();
+                    if (transfer != null && transfer.getToEnvelope() != null && !transfer.getToEnvelope().isEmpty()) {
+                        double amount = Math.abs(transaction.getAmount());
 
-                            if (isSourceSide) {
-                                outgoingTransferTotal += amount;
-                            } else {
-                                incomingTransferTotal += amount;
-                            }
-
-                            String summaryKey;
-                            String labelPrefix;
-                            String relatedEnvelopeName;
-                            if (isSourceSide) {
-                                summaryKey = "to:" + transfer.getToEnvelope();
-                                labelPrefix = "To";
-                                relatedEnvelopeName = transfer.getToEnvelope();
-                            } else {
-                                String ownerName = ownerEnvelope != null ? ownerEnvelope.getName() : transfer.getToEnvelope();
-                                summaryKey = "from:" + ownerName;
-                                labelPrefix = "From";
-                                relatedEnvelopeName = ownerName;
-                            }
-
-                            TransferTotalsOption existing = transferTotalsByEnvelope.get(summaryKey);
-                            double running = existing != null ? existing.total : 0d;
-                            if (isSourceSide) {
-                                running += amount;
-                                if (destinationSelected) {
-                                    running -= amount;
-                                }
-                            } else {
-                                running += amount;
-                            }
-                            transferTotalsByEnvelope.put(summaryKey,
-                                    new TransferTotalsOption(summaryKey, labelPrefix, relatedEnvelopeName, running));
+                        if (isSourceSide) {
+                            outgoingTransferTotal += amount;
+                        } else {
+                            incomingTransferTotal += amount;
                         }
+
+                        String summaryKey;
+                        String labelPrefix;
+                        String relatedEnvelopeName;
+                        if (isSourceSide) {
+                            summaryKey = "to:" + transfer.getToEnvelope();
+                            labelPrefix = "To";
+                            relatedEnvelopeName = transfer.getToEnvelope();
+                        } else {
+                            String ownerName = ownerEnvelope != null ? ownerEnvelope.getName() : transfer.getToEnvelope();
+                            summaryKey = "from:" + ownerName;
+                            labelPrefix = "From";
+                            relatedEnvelopeName = ownerName;
+                        }
+
+                        TransferTotalsOption existing = transferTotalsByEnvelope.get(summaryKey);
+                        double running = existing != null ? existing.total : 0d;
+                        if (isSourceSide) {
+                            running += amount;
+                            if (destinationSelected) {
+                                running -= amount;
+                            }
+                        } else {
+                            running += amount;
+                            if (ownerSelected) {
+                                running -= amount;
+                            }
+                        }
+                        transferTotalsByEnvelope.put(summaryKey,
+                                new TransferTotalsOption(summaryKey, labelPrefix, relatedEnvelopeName, running));
                     }
                 } catch (ParseException e) {
                     Log.d("EnvelopeMoney", "Transaction date parse failed", e);

--- a/app/src/main/java/com/example/envelopemoney/MainActivity.java
+++ b/app/src/main/java/com/example/envelopemoney/MainActivity.java
@@ -66,10 +66,14 @@ public class MainActivity extends AppCompatActivity {
 
 
     private static class TransferTotalsOption {
+        final String optionKey;
+        final String labelPrefix;
         final String envelopeName;
         final double total;
 
-        TransferTotalsOption(String envelopeName, double total) {
+        TransferTotalsOption(String optionKey, String labelPrefix, String envelopeName, double total) {
+            this.optionKey = optionKey;
+            this.labelPrefix = labelPrefix;
             this.envelopeName = envelopeName;
             this.total = total;
         }
@@ -440,6 +444,14 @@ public class MainActivity extends AppCompatActivity {
                 android.R.layout.simple_spinner_item, getEnvelopeNames());
         envelopeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinnerEnvelope.setAdapter(envelopeAdapter);
+        String savedSourceEnvelope = PrefManager.getLastAddTransactionEnvelope(this);
+        List<String> envelopeNames = getEnvelopeNames();
+        if (savedSourceEnvelope != null) {
+            int savedSourceIndex = envelopeNames.indexOf(savedSourceEnvelope);
+            if (savedSourceIndex >= 0) {
+                spinnerEnvelope.setSelection(savedSourceIndex);
+            }
+        }
 
         List<Integer> selectedRecurringDays = new ArrayList<>();
         final String[] selectedRecurringFrequency = new String[]{"weekly"};
@@ -546,7 +558,8 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 String source = parent.getItemAtPosition(position).toString();
-                populateTransferDestinationSpinner(spinnerTransferDestination, source, null);
+                String savedDestination = PrefManager.getLastAddTransferDestination(MainActivity.this, source);
+                populateTransferDestinationSpinner(spinnerTransferDestination, source, savedDestination);
             }
 
             @Override
@@ -554,7 +567,9 @@ public class MainActivity extends AppCompatActivity {
             }
         });
         if (spinnerEnvelope.getSelectedItem() != null) {
-            populateTransferDestinationSpinner(spinnerTransferDestination, spinnerEnvelope.getSelectedItem().toString(), null);
+            String source = spinnerEnvelope.getSelectedItem().toString();
+            String savedDestination = PrefManager.getLastAddTransferDestination(this, source);
+            populateTransferDestinationSpinner(spinnerTransferDestination, source, savedDestination);
         }
 
         cbIsTransfer.setOnCheckedChangeListener((buttonView, isChecked) ->
@@ -569,6 +584,7 @@ public class MainActivity extends AppCompatActivity {
                         double amount = Double.parseDouble(etAmount.getText().toString());
                         String comment = etComment.getText().toString();
                         String date = etDate.getText().toString();
+                        PrefManager.setLastAddTransactionEnvelope(MainActivity.this, envelopeName);
 
                         Transaction newTransaction = new Transaction(envelopeName, amount, date, comment);
                         if (cbIsRecurring.isChecked()) {
@@ -596,6 +612,7 @@ public class MainActivity extends AppCompatActivity {
                                 return;
                             }
                             destination = spinnerTransferDestination.getSelectedItem().toString();
+                            PrefManager.setLastAddTransferDestination(MainActivity.this, envelopeName, destination);
                             if (destination.equals(envelopeName)) {
                                 showError("Transfer destination must be a different envelope");
                                 return;
@@ -640,7 +657,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         List<Transaction> filteredTransactions = new ArrayList<>();
-        Map<String, Double> transferTotalsByEnvelope = new HashMap<>();
+        Map<String, TransferTotalsOption> transferTotalsByEnvelope = new HashMap<>();
         double grossTotal = 0;
         double outgoingTransferTotal = 0;
         double incomingTransferTotal = 0;
@@ -648,8 +665,7 @@ public class MainActivity extends AppCompatActivity {
         for (Envelope envelope : envelopes) {
             boolean includeEnvelope = envelope.isSelected();
             for (Transaction transaction : envelope.getTransactions()) {
-                boolean includeTransaction = includeEnvelope || (showTransfers && transaction.getTransferId() != null && !transaction.getTransferId().isEmpty());
-                if (!includeTransaction) {
+                if (!includeEnvelope) {
                     continue;
                 }
                 try {
@@ -676,16 +692,32 @@ public class MainActivity extends AppCompatActivity {
                                 incomingTransferTotal += amount;
                             }
 
-                            // Show transfer totals for both directions so opposite envelopes appear,
-                            // and cancel to zero when both sides are selected.
-                            double running = transferTotalsByEnvelope.getOrDefault(transfer.getToEnvelope(), 0d);
+                            String summaryKey;
+                            String labelPrefix;
+                            String relatedEnvelopeName;
+                            if (isSourceSide) {
+                                summaryKey = "to:" + transfer.getToEnvelope();
+                                labelPrefix = "To";
+                                relatedEnvelopeName = transfer.getToEnvelope();
+                            } else {
+                                String ownerName = ownerEnvelope != null ? ownerEnvelope.getName() : transfer.getToEnvelope();
+                                summaryKey = "from:" + ownerName;
+                                labelPrefix = "From";
+                                relatedEnvelopeName = ownerName;
+                            }
+
+                            TransferTotalsOption existing = transferTotalsByEnvelope.get(summaryKey);
+                            double running = existing != null ? existing.total : 0d;
                             if (isSourceSide) {
                                 running += amount;
+                                if (destinationSelected) {
+                                    running -= amount;
+                                }
+                            } else {
+                                running += amount;
                             }
-                            if (destinationSelected) {
-                                running -= amount;
-                            }
-                            transferTotalsByEnvelope.put(transfer.getToEnvelope(), running);
+                            transferTotalsByEnvelope.put(summaryKey,
+                                    new TransferTotalsOption(summaryKey, labelPrefix, relatedEnvelopeName, running));
                         }
                     }
                 } catch (ParseException e) {
@@ -712,7 +744,7 @@ public class MainActivity extends AppCompatActivity {
 
         double displayTotal = showTransfers ? (grossTotal - outgoingTransferTotal + incomingTransferTotal) : grossTotal;
         tvTransactionsTotal.setText(String.format(Locale.getDefault(), "Total: $%.2f", displayTotal));
-        updateTransferTotalsPanel(transferTotalsByEnvelope);
+        updateTransferTotalsPanel(new ArrayList<>(transferTotalsByEnvelope.values()));
 
         transactionAdapter.notifyDataSetChanged();
     }
@@ -2063,7 +2095,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
     }
-    private void updateTransferTotalsPanel(Map<String, Double> totalsByEnvelope) {
+    private void updateTransferTotalsPanel(List<TransferTotalsOption> options) {
         if (layoutTransferTotals == null || spinnerTransferTotals == null || tvTransferTotalsSummary == null) {
             return;
         }
@@ -2076,28 +2108,44 @@ public class MainActivity extends AppCompatActivity {
 
         layoutTransferTotals.setVisibility(View.VISIBLE);
 
-        List<TransferTotalsOption> options = new ArrayList<>();
-        for (Map.Entry<String, Double> entry : totalsByEnvelope.entrySet()) {
-            options.add(new TransferTotalsOption(entry.getKey(), entry.getValue()));
-        }
-        options.sort((a, b) -> a.envelopeName.compareToIgnoreCase(b.envelopeName));
+        options.sort((a, b) -> {
+            int prefixCompare = a.labelPrefix.compareToIgnoreCase(b.labelPrefix);
+            if (prefixCompare != 0) {
+                return prefixCompare;
+            }
+            return a.envelopeName.compareToIgnoreCase(b.envelopeName);
+        });
 
         if (options.isEmpty()) {
             spinnerTransferTotals.setOnItemSelectedListener(null);
             spinnerTransferTotals.setVisibility(View.GONE);
             tvTransferTotalsSummary.setText("No transfers in range");
             selectedTransferTotalsIndex = 0;
+            PrefManager.clearLastTransferTotalsOptionKey(this);
             return;
         }
 
         List<String> labels = new ArrayList<>();
         for (TransferTotalsOption option : options) {
-            labels.add("To " + option.envelopeName);
+            labels.add(option.labelPrefix + " " + option.envelopeName);
         }
 
-        if (selectedTransferTotalsIndex < 0 || selectedTransferTotalsIndex >= options.size()) {
+        String savedOptionKey = PrefManager.getLastTransferTotalsOptionKey(this);
+        int restoredIndex = -1;
+        if (savedOptionKey != null) {
+            for (int i = 0; i < options.size(); i++) {
+                if (Objects.equals(options.get(i).optionKey, savedOptionKey)) {
+                    restoredIndex = i;
+                    break;
+                }
+            }
+        }
+        if (restoredIndex >= 0) {
+            selectedTransferTotalsIndex = restoredIndex;
+        } else if (selectedTransferTotalsIndex < 0 || selectedTransferTotalsIndex >= options.size()) {
             selectedTransferTotalsIndex = 0;
         }
+        PrefManager.setLastTransferTotalsOptionKey(this, options.get(selectedTransferTotalsIndex).optionKey);
 
         ArrayAdapter<String> adapter = new ArrayAdapter<>(this,
                 android.R.layout.simple_spinner_item,
@@ -2113,6 +2161,7 @@ public class MainActivity extends AppCompatActivity {
                 @Override
                 public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                     selectedTransferTotalsIndex = position;
+                    PrefManager.setLastTransferTotalsOptionKey(MainActivity.this, options.get(position).optionKey);
                     tvTransferTotalsSummary.setText(formatTransferTotalsSummary(options.get(position)));
                 }
 
@@ -2125,11 +2174,12 @@ public class MainActivity extends AppCompatActivity {
             spinnerTransferTotals.setVisibility(View.GONE);
             tvTransferTotalsSummary.setText(formatTransferTotalsSummary(options.get(0)));
             selectedTransferTotalsIndex = 0;
+            PrefManager.setLastTransferTotalsOptionKey(this, options.get(0).optionKey);
         }
     }
 
     private String formatTransferTotalsSummary(TransferTotalsOption option) {
-        return String.format(Locale.getDefault(), "To %s: $%.2f", option.envelopeName, option.total);
+        return String.format(Locale.getDefault(), "%s %s: $%.2f", option.labelPrefix, option.envelopeName, option.total);
     }
     private void updateTransferToggleButton(ImageButton button) {
         int color = showTransfers

--- a/app/src/main/java/com/example/envelopemoney/MainActivity.java
+++ b/app/src/main/java/com/example/envelopemoney/MainActivity.java
@@ -578,60 +578,66 @@ public class MainActivity extends AppCompatActivity {
 
         builder.setView(dialogView)
                 .setTitle("New Transaction")
-                .setPositiveButton("Save", (dialog, which) -> {
-                    try {
-                        String envelopeName = spinnerEnvelope.getSelectedItem().toString();
-                        double amount = Double.parseDouble(etAmount.getText().toString());
-                        String comment = etComment.getText().toString();
-                        String date = etDate.getText().toString();
-                        PrefManager.setLastAddTransactionEnvelope(MainActivity.this, envelopeName);
+                .setPositiveButton("Save", null)
+                .setNegativeButton("Cancel", null);
 
-                        Transaction newTransaction = new Transaction(envelopeName, amount, date, comment);
-                        if (cbIsRecurring.isChecked()) {
-                            if (selectedRecurringDays.isEmpty()) {
-                                showError("Recurring requires at least one selected day");
-                                return;
-                            }
-                            newTransaction.setRecurring(true);
-                            newTransaction.setRecurringFrequency(selectedRecurringFrequency[0]);
-                            newTransaction.setRecurringDays(selectedRecurringDays);
-                            newTransaction.setRecurringSeriesId(UUID.randomUUID().toString());
-                            newTransaction.setRecurringTemplate(true);
-                        }
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(ignored -> dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            try {
+                String envelopeName = spinnerEnvelope.getSelectedItem().toString();
+                double amount = Double.parseDouble(etAmount.getText().toString());
+                String comment = etComment.getText().toString();
+                String date = etDate.getText().toString();
 
-                        Envelope env = findEnvelopeByName(envelopeName);
-                        if (env == null) {
-                            showError("Envelope not found");
-                            return;
-                        }
-
-                        String destination = null;
-                        if (cbIsTransfer.isChecked()) {
-                            if (spinnerTransferDestination.getSelectedItem() == null) {
-                                showError("Select where this transfer goes");
-                                return;
-                            }
-                            destination = spinnerTransferDestination.getSelectedItem().toString();
-                            PrefManager.setLastAddTransferDestination(MainActivity.this, envelopeName, destination);
-                            if (destination.equals(envelopeName)) {
-                                showError("Transfer destination must be a different envelope");
-                                return;
-                            }
-                        }
-
-                        env.addTransaction(newTransaction, currentMonth);
-                        if (destination != null) {
-                            upsertTransferForTransaction(newTransaction, envelopeName, destination, Math.abs(amount));
-                        }
-                        PrefManager.saveEnvelopes(MainActivity.this, envelopes);
-                        updateDisplay();
-                    } catch (NumberFormatException e) {
-                        showError("Invalid amount entered!");
+                Transaction newTransaction = new Transaction(envelopeName, amount, date, comment);
+                if (cbIsRecurring.isChecked()) {
+                    if (selectedRecurringDays.isEmpty()) {
+                        showError("Recurring requires at least one selected day");
+                        return;
                     }
-                })
-                .setNegativeButton("Cancel", null)
-                .create()
-                .show();
+                    newTransaction.setRecurring(true);
+                    newTransaction.setRecurringFrequency(selectedRecurringFrequency[0]);
+                    newTransaction.setRecurringDays(selectedRecurringDays);
+                    newTransaction.setRecurringSeriesId(UUID.randomUUID().toString());
+                    newTransaction.setRecurringTemplate(true);
+                }
+
+                Envelope env = findEnvelopeByName(envelopeName);
+                if (env == null) {
+                    showError("Envelope not found");
+                    return;
+                }
+
+                String destination = null;
+                if (cbIsTransfer.isChecked()) {
+                    if (spinnerTransferDestination.getSelectedItem() == null) {
+                        showError("Select where this transfer goes");
+                        return;
+                    }
+                    destination = spinnerTransferDestination.getSelectedItem().toString();
+                    if (destination.equals(envelopeName)) {
+                        showError("Transfer destination must be a different envelope");
+                        return;
+                    }
+                }
+
+                PrefManager.setLastAddTransactionEnvelope(MainActivity.this, envelopeName);
+                if (destination != null) {
+                    PrefManager.setLastAddTransferDestination(MainActivity.this, envelopeName, destination);
+                }
+
+                env.addTransaction(newTransaction, currentMonth);
+                if (destination != null) {
+                    upsertTransferForTransaction(newTransaction, envelopeName, destination, Math.abs(amount));
+                }
+                PrefManager.saveEnvelopes(MainActivity.this, envelopes);
+                updateDisplay();
+                dialog.dismiss();
+            } catch (NumberFormatException e) {
+                showError("Invalid amount entered!");
+            }
+        }));
+        dialog.show();
     }
     private void updateTransactionHistory() {
         ensureRecurringTransactionsForCurrentMonth();
@@ -1246,87 +1252,100 @@ public class MainActivity extends AppCompatActivity {
 
         builder.setView(dialogView)
                 .setTitle("Edit Transaction")
-                .setPositiveButton("Save", (dialog, which) -> {
-                    try {
-                        double newAmount = Double.parseDouble(etAmount.getText().toString());
-                        String newComment = etComment.getText().toString();
-                        String newDate = etDate.getText().toString();
-                        String oldEnvelopeName = editTransaction.getEnvelopeName();
-                        String newEnvelopeName = spinnerEnvelope.getSelectedItem().toString();
-
-                        if (cbIsRecurring.isChecked() && selectedRecurringDays.isEmpty()) {
-                            showError("Recurring requires at least one selected day");
-                            return;
-                        }
-
-                        if (!oldEnvelopeName.equals(newEnvelopeName)) {
-                            Envelope oldEnvelope = findEnvelopeByName(oldEnvelopeName);
-                            Envelope newEnvelope = findEnvelopeByName(newEnvelopeName);
-                            if (oldEnvelope != null) {
-                                oldEnvelope.getTransactions().remove(editTransaction);
-                                oldEnvelope.calculateRemaining(currentMonth);
-                            }
-                            if (newEnvelope != null) {
-                                newEnvelope.getTransactions().add(editTransaction);
-                                newEnvelope.calculateRemaining(currentMonth);
-                            }
-                            editTransaction.setEnvelopeName(newEnvelopeName);
-                        } else {
-                            Envelope envelope = findEnvelopeByName(newEnvelopeName);
-                            if (envelope != null) {
-                                envelope.updateTransaction(editTransaction, newAmount, currentMonth);
-                            }
-                        }
-
-                        editTransaction.setAmount(newAmount);
-                        editTransaction.setComment(newComment);
-                        editTransaction.setDate(newDate);
-
-                        if (cbIsRecurring.isChecked()) {
-                            editTransaction.setRecurring(true);
-                            editTransaction.setRecurringFrequency(selectedRecurringFrequency[0]);
-                            editTransaction.setRecurringDays(selectedRecurringDays);
-                            if (editTransaction.getRecurringSeriesId() == null || editTransaction.getRecurringSeriesId().isEmpty()) {
-                                editTransaction.setRecurringSeriesId(UUID.randomUUID().toString());
-                            }
-                            editTransaction.setRecurringTemplate(wasRecurringBefore ? editTransaction.isRecurringTemplate() : true);
-                        } else {
-                            editTransaction.setRecurring(false);
-                            editTransaction.setRecurringFrequency(null);
-                            editTransaction.setRecurringDays(new ArrayList<>());
-                            editTransaction.setRecurringSeriesId(null);
-                            editTransaction.setRecurringTemplate(false);
-                        }
-
-                        if (cbIsTransfer.isChecked()) {
-                            if (spinnerTransferDestination.getSelectedItem() == null) {
-                                showError("Select where this transfer goes");
-                                return;
-                            }
-                            String destination = spinnerTransferDestination.getSelectedItem().toString();
-                            if (destination.equals(newEnvelopeName)) {
-                                showError("Transfer destination must be a different envelope");
-                                return;
-                            }
-                            String sourceEnvelopeNameForTransfer = finalEditingMirrorTransfer ? destination : newEnvelopeName;
-                            String destinationEnvelopeNameForTransfer = finalEditingMirrorTransfer ? newEnvelopeName : destination;
-                            upsertTransferForTransaction(editTransaction,
-                                    sourceEnvelopeNameForTransfer,
-                                    destinationEnvelopeNameForTransfer,
-                                    Math.abs(newAmount));
-                        } else {
-                            detachTransferFromTransaction(editTransaction);
-                        }
-
-                        PrefManager.saveEnvelopes(MainActivity.this, envelopes);
-                        updateDisplay();
-                    } catch (NumberFormatException e) {
-                        showError("Invalid amount entered!");
-                    }
-                })
+                .setPositiveButton("Save", null)
                 .setNegativeButton("Cancel", null);
 
-        builder.create().show();
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(ignored -> dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(v -> {
+            try {
+                double newAmount = Double.parseDouble(etAmount.getText().toString());
+                String newComment = etComment.getText().toString();
+                String newDate = etDate.getText().toString();
+                String oldEnvelopeName = editTransaction.getEnvelopeName();
+                String newEnvelopeName = spinnerEnvelope.getSelectedItem().toString();
+                String previousMonth = resolveTransactionMonth(editTransaction);
+
+                if (cbIsRecurring.isChecked() && selectedRecurringDays.isEmpty()) {
+                    showError("Recurring requires at least one selected day");
+                    return;
+                }
+
+                String destination = null;
+                if (cbIsTransfer.isChecked()) {
+                    if (spinnerTransferDestination.getSelectedItem() == null) {
+                        showError("Select where this transfer goes");
+                        return;
+                    }
+                    destination = spinnerTransferDestination.getSelectedItem().toString();
+                    if (destination.equals(newEnvelopeName)) {
+                        showError("Transfer destination must be a different envelope");
+                        return;
+                    }
+                }
+
+                if (!oldEnvelopeName.equals(newEnvelopeName)) {
+                    Envelope oldEnvelope = findEnvelopeByName(oldEnvelopeName);
+                    Envelope newEnvelope = findEnvelopeByName(newEnvelopeName);
+                    if (oldEnvelope != null) {
+                        oldEnvelope.getTransactions().remove(editTransaction);
+                        synchronizeEnvelopeMonth(oldEnvelope, resolveTransactionMonth(editTransaction));
+                    }
+                    if (newEnvelope != null) {
+                        newEnvelope.getTransactions().add(editTransaction);
+                        synchronizeEnvelopeMonth(newEnvelope, resolveTransactionMonth(editTransaction));
+                    }
+                    editTransaction.setEnvelopeName(newEnvelopeName);
+                } else {
+                    Envelope envelope = findEnvelopeByName(newEnvelopeName);
+                    if (envelope != null) {
+                        envelope.updateTransaction(editTransaction, newAmount, currentMonth);
+                    }
+                }
+
+                editTransaction.setAmount(newAmount);
+                editTransaction.setComment(newComment);
+                editTransaction.setDate(newDate);
+
+                if (cbIsRecurring.isChecked()) {
+                    editTransaction.setRecurring(true);
+                    editTransaction.setRecurringFrequency(selectedRecurringFrequency[0]);
+                    editTransaction.setRecurringDays(selectedRecurringDays);
+                    if (editTransaction.getRecurringSeriesId() == null || editTransaction.getRecurringSeriesId().isEmpty()) {
+                        editTransaction.setRecurringSeriesId(UUID.randomUUID().toString());
+                    }
+                    editTransaction.setRecurringTemplate(wasRecurringBefore ? editTransaction.isRecurringTemplate() : true);
+                } else {
+                    editTransaction.setRecurring(false);
+                    editTransaction.setRecurringFrequency(null);
+                    editTransaction.setRecurringDays(new ArrayList<>());
+                    editTransaction.setRecurringSeriesId(null);
+                    editTransaction.setRecurringTemplate(false);
+                }
+
+                if (cbIsTransfer.isChecked()) {
+                    String sourceEnvelopeNameForTransfer = finalEditingMirrorTransfer ? destination : newEnvelopeName;
+                    String destinationEnvelopeNameForTransfer = finalEditingMirrorTransfer ? newEnvelopeName : destination;
+                    upsertTransferForTransaction(editTransaction,
+                            sourceEnvelopeNameForTransfer,
+                            destinationEnvelopeNameForTransfer,
+                            Math.abs(newAmount));
+                } else {
+                    detachTransferFromTransaction(editTransaction);
+                }
+
+                Envelope updatedEnvelope = findEnvelopeByName(editTransaction.getEnvelopeName());
+                synchronizeEnvelopeMonth(updatedEnvelope, previousMonth);
+                synchronizeEnvelopeMonth(updatedEnvelope, resolveTransactionMonth(editTransaction));
+
+                PrefManager.saveEnvelopes(MainActivity.this, envelopes);
+                updateDisplay();
+                dialog.dismiss();
+            } catch (NumberFormatException e) {
+                showError("Invalid amount entered!");
+            }
+        }));
+
+        dialog.show();
     }
     @RequiresApi(api = Build.VERSION_CODES.N)
     private void deleteTransaction(Transaction transaction) {
@@ -1909,6 +1928,30 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    private String resolveTransactionMonth(Transaction transaction) {
+        if (transaction == null) {
+            return currentMonth;
+        }
+        if (transaction.getMonth() != null && !transaction.getMonth().isEmpty()) {
+            return transaction.getMonth();
+        }
+        Date parsedDate = parseIsoDate(transaction.getDate());
+        if (parsedDate != null) {
+            return MonthTracker.formatMonth(parsedDate);
+        }
+        return currentMonth;
+    }
+
+    private void synchronizeEnvelopeMonth(Envelope envelope, String month) {
+        if (envelope == null || month == null || month.isEmpty()) {
+            return;
+        }
+        envelope.initializeMonth(month, false);
+        if (Objects.equals(month, currentMonth)) {
+            envelope.calculateRemaining(month);
+        }
+    }
+
     private void upsertTransferForTransaction(Transaction transaction, String sourceEnvelopeName, String destinationEnvelopeName, double amount) {
         String transferId = transaction.getTransferId();
         if (transferId == null || transferId.isEmpty()) {
@@ -1938,17 +1981,21 @@ public class MainActivity extends AppCompatActivity {
             sourceTransaction = transaction;
         }
 
+        String sourceTransactionMonth = resolveTransactionMonth(sourceTransaction);
         Envelope sourceHolder = findEnvelopeByName(sourceTransaction.getEnvelopeName());
         if (sourceHolder != null && sourceHolder != sourceEnvelope) {
             sourceHolder.getTransactions().remove(sourceTransaction);
-            sourceHolder.calculateRemaining(currentMonth);
-            sourceEnvelope.addTransaction(sourceTransaction, currentMonth);
+            synchronizeEnvelopeMonth(sourceHolder, sourceTransactionMonth);
+            sourceEnvelope.addTransaction(sourceTransaction, sourceTransactionMonth);
         }
 
         sourceTransaction.setEnvelopeName(sourceEnvelopeName);
         sourceTransaction.setDate(transaction.getDate());
         sourceTransaction.setComment(transaction.getComment());
-        sourceEnvelope.updateTransaction(sourceTransaction, Math.abs(amount), currentMonth);
+        String updatedSourceMonth = resolveTransactionMonth(sourceTransaction);
+        sourceEnvelope.updateTransaction(sourceTransaction, Math.abs(amount), updatedSourceMonth);
+        synchronizeEnvelopeMonth(sourceEnvelope, sourceTransactionMonth);
+        synchronizeEnvelopeMonth(sourceEnvelope, updatedSourceMonth);
 
         syncMirrorTransferTransaction(sourceTransaction, sourceEnvelopeName, destinationEnvelopeName, amount);
     }
@@ -2002,6 +2049,7 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
 
+        String mirrorTargetMonth = resolveTransactionMonth(sourceTransaction);
         Transaction mirror = null;
         Envelope mirrorEnvelope = null;
         for (Envelope envelope : envelopes) {
@@ -2017,9 +2065,7 @@ public class MainActivity extends AppCompatActivity {
                     mirrorEnvelope = envelope;
                 } else {
                     iterator.remove();
-                    if (Objects.equals(candidate.getMonth(), currentMonth)) {
-                        envelope.calculateRemaining(currentMonth);
-                    }
+                    synchronizeEnvelopeMonth(envelope, resolveTransactionMonth(candidate));
                 }
             }
         }
@@ -2032,20 +2078,26 @@ public class MainActivity extends AppCompatActivity {
         if (mirror == null) {
             mirror = new Transaction(destinationEnvelopeName, -Math.abs(amount), sourceTransaction.getDate(), mirrorComment);
             mirror.setTransferId(transferId);
-            destinationEnvelope.addTransaction(mirror, currentMonth);
+            destinationEnvelope.addTransaction(mirror, mirrorTargetMonth);
+            synchronizeEnvelopeMonth(destinationEnvelope, mirrorTargetMonth);
             return;
         }
 
         if (mirrorEnvelope != null && mirrorEnvelope != destinationEnvelope) {
+            String previousMirrorMonth = resolveTransactionMonth(mirror);
             mirrorEnvelope.getTransactions().remove(mirror);
-            mirrorEnvelope.calculateRemaining(currentMonth);
-            destinationEnvelope.addTransaction(mirror, currentMonth);
+            synchronizeEnvelopeMonth(mirrorEnvelope, previousMirrorMonth);
+            destinationEnvelope.addTransaction(mirror, previousMirrorMonth);
         }
 
+        String previousMirrorMonth = resolveTransactionMonth(mirror);
         mirror.setEnvelopeName(destinationEnvelopeName);
         mirror.setDate(sourceTransaction.getDate());
         mirror.setComment(mirrorComment);
-        destinationEnvelope.updateTransaction(mirror, -Math.abs(amount), currentMonth);
+        String updatedMirrorMonth = resolveTransactionMonth(mirror);
+        destinationEnvelope.updateTransaction(mirror, -Math.abs(amount), updatedMirrorMonth);
+        synchronizeEnvelopeMonth(destinationEnvelope, previousMirrorMonth);
+        synchronizeEnvelopeMonth(destinationEnvelope, updatedMirrorMonth);
     }
 
     private void removeMirrorTransactions(String transferId, Transaction anchorTransaction) {

--- a/app/src/main/java/com/example/envelopemoney/MainActivity.java
+++ b/app/src/main/java/com/example/envelopemoney/MainActivity.java
@@ -117,26 +117,25 @@ public class MainActivity extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        // Load envelopes
+        // Load envelopes through the rollover repair path so startup only adopts sanitized state.
         envelopes = PrefManager.getEnvelopes(this);
         if(TEST){
             addData();
         }
 
-        if (MonthTracker.isFirstMonth(this)) {
-            // Initialize with current transactions
-            String currentMonth = MonthTracker.formatMonth(new Date());
-            for (Envelope env : envelopes) {
-                env.initializeMonth(currentMonth, false);
-                env.migrateLegacyTransactions(currentMonth);
-            }
-        }
+        MonthRolloverHelper.Result launchState = MonthRolloverHelper.prepareForLaunch(
+                envelopes,
+                MonthTracker.getStoredMonthOrNull(this),
+                MonthTracker.getRealCurrentMonth(),
+                true
+        );
+        envelopes = launchState.getEnvelopes();
         // Initialize total view
         tvTransactionsTotal = findViewById(R.id.tvTransactionsTotal);
-        currentMonth = MonthTracker.getCurrentMonth(this);
-        // Check for new month
-        if (MonthTracker.isNewMonth(this)) {
-            handleNewMonth(true); // Auto-reset with carry-over
+        currentMonth = launchState.getActiveMonth();
+        MonthTracker.setCurrentMonth(this, currentMonth);
+        if (launchState.requiresPersistence()) {
+            PrefManager.saveEnvelopes(this, envelopes);
         }
         setupMonthNavigation();
         setupDatePickers();
@@ -300,61 +299,26 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void handleNewMonth(boolean carryOver) {
-        if (monthRolloverInProgress) return;                 // prevent re-entry
+        if (monthRolloverInProgress) return;
         monthRolloverInProgress = true;
         try {
-            final String newMonth = MonthTracker.formatMonth(new Date());
-            final String alreadySet = MonthTracker.getCurrentMonth(this);
-            if (newMonth.equals(alreadySet)) return;         // nothing to do (idempotent)
-
-            // Work on a snapshot to avoid ConcurrentModification during UI binds
-            List<Envelope> snapshot = new ArrayList<>(envelopes);
-
-            for (Envelope env : snapshot) {
-                // ---- null-safety (see section 2) ----
-                double orig = safe(env.getOriginalLimit());
-                double rem  = safe(env.getRemaining());
-                Double manual = env.getManualRemaining();
-                double manualVal = (manual != null) ? manual : rem;
-
-                if (carryOver) {
-                    double newTotal = orig + manualVal;      // base + leftover (manual preferred)
-                    // Seed *both* manual + baselines so later recomputes are correct
-                    env.setManualRemaining(newTotal);
-                    // If you have baseline fields, seed them here too
-                    if (env.hasBaseline()) {
-                        env.setBaselineRemaining(newTotal);
-                        env.setBaselineLimit(newTotal);     // or env.getLimit() if that’s your anchor
-                    }
-                    env.setRemaining(newTotal);
-                } else {
-                    env.setManualRemaining(null);
-                    if (env.hasBaseline()) {
-                        env.setBaselineRemaining(orig);
-                        env.setBaselineLimit(orig);
-                    }
-                    env.setRemaining(orig);
-                }
-
-                // Ensure monthlyData exists for newMonth
-                env.initializeMonth(newMonth, carryOver);
-            }
-
-            // Commit month AFTER envelopes are stable
-            currentMonth = newMonth;
-            MonthTracker.setCurrentMonth(this, newMonth);
-
-            // One clean UI refresh at the end
+            MonthRolloverHelper.Result rolloverResult = MonthRolloverHelper.prepareForLaunch(
+                    envelopes,
+                    currentMonth,
+                    MonthTracker.getRealCurrentMonth(),
+                    carryOver
+            );
+            envelopes = rolloverResult.getEnvelopes();
+            currentMonth = rolloverResult.getActiveMonth();
+            MonthTracker.setCurrentMonth(this, currentMonth);
             PrefManager.saveEnvelopes(this, envelopes);
             if (envelopeAdapter != null && transactionAdapter != null) {
+                envelopeAdapter = new EnvelopeAdapter(this, envelopes);
+                listViewEnvelopes.setAdapter(envelopeAdapter);
                 updateDisplay();
             }
-
-        } catch (Throwable t) {
-            // Don’t crash-loop: surface a message and swallow the exception
-//            showError("We hit a rollover issue: " + t.getClass().getSimpleName());
-            // Optional: Log.d("EnvelopeMoney", "Rollover crash", t);
-            Log.d("EnvelopeMoney", "Rollover crash", t);
+        } catch (RuntimeException exception) {
+            Log.d("EnvelopeMoney", "Rollover recovery failed", exception);
         } finally {
             monthRolloverInProgress = false;
         }
@@ -363,53 +327,6 @@ public class MainActivity extends AppCompatActivity {
         if (v == null) return 0d;
         if (Double.isNaN(v) || Double.isInfinite(v)) return 0d;
         return v;
-    }
-
-
-    private void changeMonth(int direction) {
-        if (currentMonth == null || currentMonth.isEmpty()) {
-            return;
-        }
-        try {
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
-            Date date = sdf.parse(currentMonth);
-            if (date == null) {
-                return;
-            }
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(date);
-            cal.add(Calendar.MONTH, direction);
-            String newMonth = sdf.format(cal.getTime());
-
-            // Prevent navigating to future months
-            if (newMonth.compareTo(MonthTracker.formatMonth(new Date())) > 0) {
-                return;
-            }
-            currentMonth = newMonth;
-            MonthTracker.setCurrentMonth(this, newMonth);
-            refreshDataForMonth();
-            setupMonthNavigation();
-            updateDisplay();
-        } catch (Exception e) {
-            Log.d("EnvelopeMoney", "Month navigation failed", e);
-        }
-    }
-    private void refreshDataForMonth() {
-        // Load data for current month
-        for (Envelope env : envelopes) {
-            env.getMonthlyData(currentMonth); // Initialize if needed
-        }
-        updateDisplay();
-    }
-    private String formatDisplayMonth(String month) {
-        try {
-            SimpleDateFormat inputFormat = new SimpleDateFormat("yyyy-MM", Locale.getDefault());
-            SimpleDateFormat outputFormat = new SimpleDateFormat("MMM yyyy", Locale.getDefault());
-            Date date = inputFormat.parse(month);
-            return outputFormat.format(date);
-        } catch (ParseException e) {
-            return month;
-        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)

--- a/app/src/main/java/com/example/envelopemoney/MonthRolloverHelper.java
+++ b/app/src/main/java/com/example/envelopemoney/MonthRolloverHelper.java
@@ -1,0 +1,173 @@
+package com.example.envelopemoney;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Centralizes startup month-state repair and rollover so the activity only adopts a fully valid state.
+ * The helper works on a deep copy of the envelope list to avoid half-applied mutations when repair fails.
+ */
+public final class MonthRolloverHelper {
+    private static final Gson GSON = new Gson();
+
+    public static final class Result {
+        private final List<Envelope> envelopes;
+        private final String activeMonth;
+        private final boolean requiresPersistence;
+        private final boolean rolledOver;
+        private final List<String> warnings;
+
+        Result(List<Envelope> envelopes,
+               String activeMonth,
+               boolean requiresPersistence,
+               boolean rolledOver,
+               List<String> warnings) {
+            this.envelopes = envelopes;
+            this.activeMonth = activeMonth;
+            this.requiresPersistence = requiresPersistence;
+            this.rolledOver = rolledOver;
+            this.warnings = warnings;
+        }
+
+        public List<Envelope> getEnvelopes() {
+            return envelopes;
+        }
+
+        public String getActiveMonth() {
+            return activeMonth;
+        }
+
+        public boolean requiresPersistence() {
+            return requiresPersistence;
+        }
+
+        public boolean rolledOver() {
+            return rolledOver;
+        }
+
+        public List<String> getWarnings() {
+            return warnings;
+        }
+    }
+
+    private MonthRolloverHelper() {
+    }
+
+    public static Result prepareForLaunch(List<Envelope> sourceEnvelopes,
+                                          String storedMonth,
+                                          String actualMonth,
+                                          boolean carryOver) {
+        String resolvedActualMonth = MonthTracker.normalizeMonth(actualMonth);
+        if (resolvedActualMonth == null) {
+            resolvedActualMonth = MonthTracker.getRealCurrentMonth();
+        }
+        String resolvedStoredMonth = MonthTracker.normalizeMonth(storedMonth);
+        String fallbackMonth = resolvedStoredMonth != null ? resolvedStoredMonth : resolvedActualMonth;
+
+        List<String> warnings = new ArrayList<>();
+        List<Envelope> workingCopy = deepCopy(sourceEnvelopes);
+        if (workingCopy == null) {
+            workingCopy = new ArrayList<>();
+            warnings.add("Recovered from unreadable envelope state");
+        }
+
+        sanitizeEnvelopeList(workingCopy, fallbackMonth, warnings);
+
+        boolean rolloverNeeded = MonthTracker.shouldRollover(resolvedStoredMonth, resolvedActualMonth);
+        if (rolloverNeeded) {
+            for (Envelope envelope : workingCopy) {
+                applyRollover(envelope, fallbackMonth, resolvedActualMonth, carryOver, warnings);
+            }
+        } else {
+            for (Envelope envelope : workingCopy) {
+                envelope.sanitizeState(resolvedActualMonth);
+                envelope.rebuildMonthData(resolvedActualMonth);
+                if (envelope.getManualRemaining() == null) {
+                    envelope.setRemaining(envelope.getMonthlyData(resolvedActualMonth).remaining);
+                }
+            }
+        }
+
+        return new Result(workingCopy,
+                resolvedActualMonth,
+                rolloverNeeded || resolvedStoredMonth == null || !warnings.isEmpty(),
+                rolloverNeeded,
+                warnings);
+    }
+
+    private static void sanitizeEnvelopeList(List<Envelope> envelopes, String fallbackMonth, List<String> warnings) {
+        envelopes.removeIf(envelope -> envelope == null);
+        for (Envelope envelope : envelopes) {
+            try {
+                envelope.sanitizeState(fallbackMonth);
+            } catch (RuntimeException exception) {
+                warnings.add("Repaired envelope state for " + envelope.getName());
+                envelope.getTransactions().clear();
+                envelope.getTransfers().clear();
+                envelope.getMonthlyDataMap().clear();
+                envelope.sanitizeState(fallbackMonth);
+            }
+        }
+    }
+
+    private static void applyRollover(Envelope envelope,
+                                      String sourceMonth,
+                                      String targetMonth,
+                                      boolean carryOver,
+                                      List<String> warnings) {
+        envelope.sanitizeState(sourceMonth);
+        envelope.rebuildMonthData(sourceMonth);
+
+        double originalLimit = safeFinite(envelope.getOriginalLimit(), envelope.getLimit());
+        double sourceRemaining = resolveCarryOverRemaining(envelope, originalLimit);
+        double targetLimit = carryOver ? originalLimit + sourceRemaining : originalLimit;
+        targetLimit = safeFinite(targetLimit, originalLimit);
+
+        envelope.setOriginalLimit(originalLimit);
+        envelope.setLimit(originalLimit);
+        envelope.setBaselineLimit(targetLimit);
+        envelope.setBaselineRemaining(targetLimit);
+        envelope.setManualRemaining(carryOver ? targetLimit : null);
+        envelope.setRemaining(targetLimit);
+        envelope.replaceMonthData(targetMonth, targetLimit);
+
+        if (!targetMonth.equals(sourceMonth)) {
+            envelope.rebuildMonthData(sourceMonth);
+        }
+        if (carryOver && targetLimit < 0d) {
+            warnings.add("Negative carry-over was normalized for " + envelope.getName());
+        }
+    }
+
+    private static double resolveCarryOverRemaining(Envelope envelope, double fallbackValue) {
+        Double manualRemaining = envelope.getManualRemaining();
+        if (manualRemaining != null && Double.isFinite(manualRemaining)) {
+            return manualRemaining;
+        }
+        double remaining = envelope.getRemaining();
+        if (Double.isFinite(remaining)) {
+            return remaining;
+        }
+        return fallbackValue;
+    }
+
+    private static double safeFinite(double primary, double fallback) {
+        if (Double.isFinite(primary)) {
+            return primary;
+        }
+        if (Double.isFinite(fallback)) {
+            return fallback;
+        }
+        return 0d;
+    }
+
+    private static List<Envelope> deepCopy(List<Envelope> envelopes) {
+        Type type = new TypeToken<ArrayList<Envelope>>() { }.getType();
+        String json = GSON.toJson(envelopes == null ? new ArrayList<Envelope>() : envelopes, type);
+        return GSON.fromJson(json, type);
+    }
+}

--- a/app/src/main/java/com/example/envelopemoney/MonthTracker.java
+++ b/app/src/main/java/com/example/envelopemoney/MonthTracker.java
@@ -6,21 +6,27 @@ import android.content.SharedPreferences;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class MonthTracker {
     private static final String CURRENT_MONTH_KEY = "current_month";
     private static final String MONTH_FORMAT = "yyyy-MM";
+    private static final Pattern MONTH_PATTERN = Pattern.compile("^\\d{4}-\\d{2}$");
+
+    public static String getStoredMonthOrNull(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
+        return normalizeMonth(prefs.getString(CURRENT_MONTH_KEY, null));
+    }
 
     public static String getCurrentMonth(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
-        String stored = prefs.getString(CURRENT_MONTH_KEY, "");
-        if (!stored.isEmpty()) return stored;
-        return new SimpleDateFormat(MONTH_FORMAT, Locale.getDefault()).format(new Date());
+        String stored = getStoredMonthOrNull(context);
+        if (stored != null) return stored;
+        return getRealCurrentMonth();
     }
 
     public static void setCurrentMonth(Context context, String month) {
         SharedPreferences.Editor editor = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE).edit();
-        editor.putString(CURRENT_MONTH_KEY, month);
+        editor.putString(CURRENT_MONTH_KEY, normalizeMonth(month));
         editor.apply();
     }
 
@@ -28,12 +34,34 @@ public class MonthTracker {
         return new SimpleDateFormat(MONTH_FORMAT, Locale.getDefault()).format(date);
     }
 
+    public static String getRealCurrentMonth() {
+        return formatMonth(new Date());
+    }
+
+    public static String normalizeMonth(String month) {
+        if (month == null) {
+            return null;
+        }
+        String trimmed = month.trim();
+        if (!MONTH_PATTERN.matcher(trimmed).matches()) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    public static boolean shouldRollover(String storedMonth, String actualMonth) {
+        String normalizedActual = normalizeMonth(actualMonth);
+        if (normalizedActual == null) {
+            normalizedActual = getRealCurrentMonth();
+        }
+        String normalizedStored = normalizeMonth(storedMonth);
+        return normalizedStored == null || !normalizedStored.equals(normalizedActual);
+    }
+
     public static boolean isNewMonth(Context context) {
-        String current = formatMonth(new Date());
-        return !current.equals(getCurrentMonth(context));
+        return shouldRollover(getStoredMonthOrNull(context), getRealCurrentMonth());
     }
     public static boolean isFirstMonth(Context context) {
-        SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
-        return !prefs.contains(CURRENT_MONTH_KEY);
+        return getStoredMonthOrNull(context) == null;
     }
 }

--- a/app/src/main/java/com/example/envelopemoney/PrefManager.java
+++ b/app/src/main/java/com/example/envelopemoney/PrefManager.java
@@ -42,8 +42,13 @@ public class PrefManager {
         String json = prefs.getString(ENVELOPES_KEY, null);
         if (json == null) return createDefaultEnvelopes(context);
 
-        Type type = new TypeToken<ArrayList<Envelope>>(){}.getType();
-        return new Gson().fromJson(json, (java.lang.reflect.Type) type);
+        try {
+            Type type = new TypeToken<ArrayList<Envelope>>(){}.getType();
+            List<Envelope> envelopes = new Gson().fromJson(json, (java.lang.reflect.Type) type);
+            return envelopes != null ? envelopes : createDefaultEnvelopes(context);
+        } catch (RuntimeException exception) {
+            return createDefaultEnvelopes(context);
+        }
     }
 
     public static void setEnvelopesCollapsed(Context context, boolean collapsed) {

--- a/app/src/main/java/com/example/envelopemoney/PrefManager.java
+++ b/app/src/main/java/com/example/envelopemoney/PrefManager.java
@@ -15,6 +15,9 @@ public class PrefManager {
     private static final String PREFS_NAME = "envelope_prefs";
     private static final String ENVELOPES_KEY = "envelopes";
     private static final String ENVELOPES_COLLAPSED_KEY = "envelopes_collapsed";
+    private static final String LAST_ADD_TRANSACTION_ENVELOPE_KEY = "last_add_transaction_envelope";
+    private static final String LAST_ADD_TRANSFER_DESTINATION_PREFIX = "last_add_transfer_destination_";
+    private static final String LAST_TRANSFER_TOTALS_OPTION_KEY = "last_transfer_totals_option";
     private String name;
     private double limit;
     private double remaining;
@@ -52,6 +55,51 @@ public class PrefManager {
     public static boolean isEnvelopesCollapsed(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getBoolean(ENVELOPES_COLLAPSED_KEY, false);
+    }
+
+    public static void setLastAddTransactionEnvelope(Context context, String envelopeName) {
+        SharedPreferences.Editor editor = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit();
+        editor.putString(LAST_ADD_TRANSACTION_ENVELOPE_KEY, envelopeName);
+        editor.apply();
+    }
+
+    public static String getLastAddTransactionEnvelope(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(LAST_ADD_TRANSACTION_ENVELOPE_KEY, null);
+    }
+
+    public static void setLastAddTransferDestination(Context context, String sourceEnvelopeName, String destinationEnvelopeName) {
+        if (sourceEnvelopeName == null || sourceEnvelopeName.isEmpty()) {
+            return;
+        }
+        SharedPreferences.Editor editor = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit();
+        editor.putString(LAST_ADD_TRANSFER_DESTINATION_PREFIX + sourceEnvelopeName, destinationEnvelopeName);
+        editor.apply();
+    }
+
+    public static String getLastAddTransferDestination(Context context, String sourceEnvelopeName) {
+        if (sourceEnvelopeName == null || sourceEnvelopeName.isEmpty()) {
+            return null;
+        }
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(LAST_ADD_TRANSFER_DESTINATION_PREFIX + sourceEnvelopeName, null);
+    }
+
+    public static void setLastTransferTotalsOptionKey(Context context, String optionKey) {
+        SharedPreferences.Editor editor = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit();
+        editor.putString(LAST_TRANSFER_TOTALS_OPTION_KEY, optionKey);
+        editor.apply();
+    }
+
+    public static String getLastTransferTotalsOptionKey(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(LAST_TRANSFER_TOTALS_OPTION_KEY, null);
+    }
+
+    public static void clearLastTransferTotalsOptionKey(Context context) {
+        SharedPreferences.Editor editor = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit();
+        editor.remove(LAST_TRANSFER_TOTALS_OPTION_KEY);
+        editor.apply();
     }
 
     private static List<Envelope> createDefaultEnvelopes(Context context) {

--- a/app/src/test/java/com/example/envelopemoney/MonthRolloverHelperTest.java
+++ b/app/src/test/java/com/example/envelopemoney/MonthRolloverHelperTest.java
@@ -1,0 +1,82 @@
+package com.example.envelopemoney;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MonthRolloverHelperTest {
+    @Test
+    public void prepareForLaunch_rollsForwardWithCarryOver() {
+        Envelope gas = new Envelope("Gas", 100d);
+        gas.setRemaining(35d);
+        gas.setManualRemaining(null);
+        gas.addTransaction(new Transaction("Gas", 65d, "2026-02-12", "Fuel"), "2026-02");
+
+        List<Envelope> envelopes = new ArrayList<>();
+        envelopes.add(gas);
+
+        MonthRolloverHelper.Result result = MonthRolloverHelper.prepareForLaunch(envelopes, "2026-02", "2026-03", true);
+
+        assertEquals("2026-03", result.getActiveMonth());
+        assertTrue(result.rolledOver());
+        Envelope rolledGas = result.getEnvelopes().get(0);
+        assertEquals(135d, rolledGas.getRemaining(), 0.001d);
+        assertEquals(135d, rolledGas.getMonthlyData("2026-03").limit, 0.001d);
+    }
+
+    @Test
+    public void prepareForLaunch_repairsLegacyTransactionMonth() {
+        Envelope personal = new Envelope("Personal", 200d);
+        Transaction transaction = new Transaction("Personal", 10d, "2026-02-10", "Lunch");
+        transaction.setMonth(null);
+        personal.getTransactions().add(transaction);
+
+        List<Envelope> envelopes = new ArrayList<>();
+        envelopes.add(personal);
+
+        MonthRolloverHelper.Result result = MonthRolloverHelper.prepareForLaunch(envelopes, "2026-02", "2026-02", true);
+
+        assertEquals("2026-02", result.getEnvelopes().get(0).getTransactions().get(0).getMonth());
+        assertEquals(190d, result.getEnvelopes().get(0).getMonthlyData("2026-02").remaining, 0.001d);
+    }
+
+    @Test
+    public void prepareForLaunch_recoversMalformedNumericState() {
+        Envelope outreach = new Envelope("Outreach", 80d);
+        outreach.setOriginalLimit(Double.NaN);
+        outreach.setRemaining(Double.NaN);
+        outreach.setManualRemaining(Double.POSITIVE_INFINITY);
+
+        List<Envelope> envelopes = new ArrayList<>();
+        envelopes.add(outreach);
+
+        MonthRolloverHelper.Result result = MonthRolloverHelper.prepareForLaunch(envelopes, "not-a-month", "2026-03", true);
+
+        Envelope repaired = result.getEnvelopes().get(0);
+        assertEquals("2026-03", result.getActiveMonth());
+        assertTrue(Double.isFinite(repaired.getOriginalLimit()));
+        assertTrue(Double.isFinite(repaired.getRemaining()));
+        assertNotNull(repaired.getMonthlyData("2026-03"));
+    }
+
+    @Test
+    public void prepareForLaunch_isIdempotentAfterSuccessfulRollover() {
+        Envelope vacation = new Envelope("Vacation", 300d);
+        vacation.setRemaining(250d);
+
+        List<Envelope> envelopes = new ArrayList<>();
+        envelopes.add(vacation);
+
+        MonthRolloverHelper.Result first = MonthRolloverHelper.prepareForLaunch(envelopes, "2026-02", "2026-03", true);
+        MonthRolloverHelper.Result second = MonthRolloverHelper.prepareForLaunch(first.getEnvelopes(), "2026-03", "2026-03", true);
+
+        assertTrue(first.rolledOver());
+        assertFalse(second.rolledOver());
+        assertEquals(first.getEnvelopes().get(0).getMonthlyData("2026-03").limit,
+                second.getEnvelopes().get(0).getMonthlyData("2026-03").limit,
+                0.001d);
+    }
+}

--- a/app/src/test/java/com/example/envelopemoney/MonthTrackerTest.java
+++ b/app/src/test/java/com/example/envelopemoney/MonthTrackerTest.java
@@ -1,0 +1,29 @@
+package com.example.envelopemoney;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MonthTrackerTest {
+    @Test
+    public void normalizeMonth_acceptsYearMonthShape() {
+        assertEquals("2026-03", MonthTracker.normalizeMonth("2026-03"));
+    }
+
+    @Test
+    public void normalizeMonth_rejectsMalformedMonth() {
+        assertNull(MonthTracker.normalizeMonth("03/2026"));
+        assertNull(MonthTracker.normalizeMonth("2026-3"));
+        assertNull(MonthTracker.normalizeMonth(""));
+    }
+
+    @Test
+    public void shouldRollover_handlesMissingStoredMonth() {
+        assertTrue(MonthTracker.shouldRollover(null, "2026-03"));
+    }
+
+    @Test
+    public void shouldRollover_detectsSameMonth() {
+        assertFalse(MonthTracker.shouldRollover("2026-03", "2026-03"));
+    }
+}

--- a/docs/AI_CHANGE_PROTOCOL.md
+++ b/docs/AI_CHANGE_PROTOCOL.md
@@ -1,0 +1,55 @@
+# AI Change Protocol
+
+The following workflow is mandatory for every AI-assisted code change in this repository.
+
+## Required Workflow
+1. Load repository memory.
+2. Log development intent.
+3. Verify architecture and user-flow impact.
+4. Implement changes.
+5. Run compile and regression checks.
+6. Add or update unit tests when behavior changes.
+7. Update documentation and task state.
+8. Update the README change log.
+9. Stage a local commit with a structured message.
+10. Do not push automatically.
+
+## Repository Memory To Load Before Changes
+- `/docs/PROJECT_INDEX.md`
+- `/docs/ARCHITECTURE.md`
+- `/docs/DATA_SCHEMA.md`
+- `/docs/features.md`
+- `/docs/user-flows.md`
+- `/state/TASK_STATE.json`
+- `/prompts/codex_rules.md`
+- `/README.md`
+
+## Required Pre-Implementation Summary
+Before code changes, summarize:
+- relevant architecture components
+- persisted data involved
+- user flow affected
+- files to be changed
+
+## Finalization Protocol
+After implementation:
+1. Ensure code compiles.
+2. Run regression tests.
+3. Add or update unit tests.
+4. Update repository memory files affected by the change.
+5. Update `README.md` change log.
+6. Stage a local commit.
+
+## Commit Format
+Allowed prefixes:
+- `feat`
+- `fix`
+- `refactor`
+- `docs`
+- `test`
+- `perf`
+
+Each commit message must include:
+- systems affected
+- behavior changed
+- tests added or updated

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,41 @@
+# Architecture
+
+## Application Shape
+EnvelopeMoney is a single-activity Android application with state persisted through SharedPreferences using Gson serialization for envelope and transaction data.
+
+## Core Components
+- `MainActivity`
+  - Owns screen initialization, envelope list, transactions list, month navigation, transfer summaries, dialogs, and rollover triggering.
+- `MonthRolloverHelper`
+  - Sanitizes persisted envelope state, repairs legacy month data, and computes a safe launch month on a deep copy before the activity adopts it.
+- `Envelope`
+  - Stores envelope balances, month snapshots, transaction membership, transfer definitions, and manual override state.
+- `Transaction`
+  - Stores amount, date, comment, transfer linkage, and recurring metadata.
+- `MonthTracker`
+  - Stores the current persisted month, normalizes month values, and determines whether rollover is required.
+- `PrefManager`
+  - Serializes/deserializes envelope state and UI preference state.
+
+## State Boundaries
+- UI state lives primarily in `MainActivity`.
+- Persisted business state lives in the serialized `Envelope` and `Transaction` models.
+- Month rollover is a business-state transition and must be deterministic, validated, and idempotent.
+
+## Startup Month Flow
+```text
+App launch
+  -> load persisted envelopes
+  -> sanitize/repair with MonthRolloverHelper
+  -> compute active month from stored month vs real month
+  -> rebuild target month data on a deep copy
+  -> adopt repaired envelopes only after success
+  -> persist current month and repaired state once
+```
+
+## Current Risk Areas
+- SharedPreferences can contain malformed or legacy state that must be repaired before rollover logic executes.
+- Gradle 6.7.1 verification is currently blocked on this machine by missing JDK 11/17 compatibility.
+
+## Target Architecture Rule
+Month rollover logic must stay isolated in testable helpers and must not mutate live persisted state until rollover inputs are sanitized and the transition is valid.

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -1,0 +1,50 @@
+# Data Schema
+
+## Persistence Store
+The app persists most business state via SharedPreferences.
+
+## SharedPreferences Areas
+- `app_prefs`
+  - `current_month`: persisted active month in `yyyy-MM`
+- `envelope_prefs`
+  - `envelopes`: Gson-serialized list of `Envelope`
+  - `envelopes_collapsed`: envelopes section UI state
+  - `last_add_transaction_envelope`
+  - `last_add_transfer_destination_<sourceEnvelope>`
+  - `last_transfer_totals_option`
+
+## Envelope Model
+- `name: String`
+- `limit: double`
+- `originalLimit: double`
+- `remaining: double`
+- `transactions: List<Transaction>`
+- `selected: boolean`
+- `monthlyData: Map<String, MonthData>`
+- `transfers: List<TransferData>`
+- `manualRemaining: Double?`
+- `baselineLimit: double`
+- `baselineRemaining: double`
+
+## MonthData Model
+- `limit: double`
+- `remaining: double`
+- `transactions: List<Transaction>`
+
+## Transaction Model
+- `envelopeName: String`
+- `amount: double`
+- `date: String`
+- `comment: String`
+- `month: String`
+- `transferId: String?`
+- `recurring: boolean`
+- `recurringFrequency: String?`
+- `recurringDays: List<Integer>`
+- `recurringSeriesId: String?`
+- `recurringTemplate: boolean`
+
+## TransferData Model
+- `id: String`
+- `toEnvelope: String`
+- `amount: double`

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -1,0 +1,35 @@
+# Project Index
+
+## Repository Structure
+```text
+EnvelopeMoney/
++-- docs/
+¦   +-- PROJECT_INDEX.md
+¦   +-- ARCHITECTURE.md
+¦   +-- DATA_SCHEMA.md
+¦   +-- features.md
+¦   +-- user-flows.md
+¦   +-- AI_CHANGE_PROTOCOL.md
++-- state/
+¦   +-- TASK_STATE.json
++-- prompts/
+¦   +-- codex_rules.md
++-- app/
+¦   +-- src/main/java/com/example/envelopemoney/
++-- README.md
+```
+
+## Key Runtime Areas
+- `MainActivity.java`: primary activity, transaction UI, envelope UI, month navigation, transfers, recurring transactions.
+- `Envelope.java`: envelope domain model, monthly data, transfer metadata, remaining balance calculations.
+- `Transaction.java`: transaction domain model with transfer and recurring metadata.
+- `MonthTracker.java`: persisted month state and rollover detection.
+- `PrefManager.java`: persisted envelopes and UI preferences.
+
+## Memory Files
+- `ARCHITECTURE.md`: module boundaries and runtime responsibilities.
+- `DATA_SCHEMA.md`: persisted JSON/shared-preferences model shape.
+- `features.md`: user-facing behavior definitions.
+- `user-flows.md`: navigation and interaction flows.
+- `AI_CHANGE_PROTOCOL.md`: mandatory AI change workflow.
+- `TASK_STATE.json`: current active/completed tasks.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,28 @@
+# Features
+
+## Envelope Budgeting
+- Users can create envelopes with monthly limits.
+- Envelopes track remaining funds and month-specific snapshots.
+- Envelopes can be collapsed in the UI and that preference is persisted.
+
+## Transactions
+- Users can add, edit, and delete transactions.
+- Transactions belong to envelopes and contribute to month totals.
+- Transactions can be filtered by selected envelopes and date range.
+
+## Transfers
+- Transfers move money between envelopes using linked transactions.
+- Source and destination sides share a transfer ID.
+- Transfer visibility can be toggled in the transactions view.
+- Transfer summaries appear in the transactions header area.
+
+## Recurring Transactions
+- Recurring transactions support weekly, bi-weekly, and monthly patterns.
+- Weekly/bi-weekly use weekday toggles.
+- Monthly uses a day-picker calendar.
+
+## Month Rollover
+- On a new month, the app sanitizes persisted state before switching months.
+- Carry-over behavior is computed on a deep copy so startup never adopts half-migrated state.
+- Malformed month strings, null month maps, null collections, and legacy transactions without a month are repaired safely.
+- The active month is persisted only after the repaired envelope state is ready.

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -1,0 +1,25 @@
+# User Flows
+
+## Launch Flow
+1. App loads persisted envelopes and stored month state.
+2. `MonthRolloverHelper` sanitizes envelope collections, numeric fields, and legacy transaction months.
+3. If a new month is required, rollover is applied on a deep copy.
+4. The repaired envelopes and active month are committed once.
+5. Envelope and transaction lists render for the active month.
+
+## Add Transaction Flow
+1. User opens the transaction dialog.
+2. User selects envelope, amount, date, comment, and optional recurring/transfer settings.
+3. Validation runs without dismissing the dialog on errors.
+4. Transaction is persisted and visible in history.
+
+## Transfer Flow
+1. User enables transfer mode in the transaction dialog.
+2. User selects the destination envelope.
+3. App persists linked source/destination transactions.
+4. Transfer rows and totals appear in the transactions view when transfer visibility is enabled.
+
+## Month Navigation Flow
+1. User navigates between months.
+2. App loads the relevant month snapshots and transactions.
+3. Future months are not navigable.

--- a/prompts/codex_rules.md
+++ b/prompts/codex_rules.md
@@ -1,0 +1,19 @@
+Before making any code changes you MUST load and read:
+
+/docs/PROJECT_INDEX.md
+/docs/ARCHITECTURE.md
+/docs/DATA_SCHEMA.md
+/docs/features.md
+/docs/user-flows.md
+/state/TASK_STATE.json
+/prompts/codex_rules.md
+README.md
+
+These files define the authoritative architecture and behavior.
+If requested changes conflict with these documents, the documents take precedence.
+
+Implementation precheck summary must include:
+1. Relevant architecture components
+2. Persisted data involved
+3. User flow affected
+4. Files to be modified

--- a/state/TASK_STATE.json
+++ b/state/TASK_STATE.json
@@ -1,0 +1,20 @@
+{
+  "active_tasks": [
+    {
+      "id": "month-rollover-hardening",
+      "title": "Verify month rollover hardening on a Gradle-compatible JDK",
+      "status": "verification_blocked"
+    }
+  ],
+  "completed_tasks": [
+    {
+      "id": "repo-memory-bootstrap",
+      "title": "Create repository memory files and AI change protocol"
+    },
+    {
+      "id": "month-rollover-refactor",
+      "title": "Add sanitized deep-copy month rollover helper and startup integration"
+    }
+  ],
+  "last_updated": "2026-03-21"
+}


### PR DESCRIPTION
Remember and restore envelope/transfer UI selections to improve UX. Expanded TransferTotalsOption with optionKey and labelPrefix and switched transfer totals aggregation to use a Map of TransferTotalsOption entries (keys like "to:Name"/"from:Name") so summaries can show "To/From <Envelope>: $X". MainActivity now pre-selects the last-used add-transaction envelope and per-source transfer destination, saves selections when creating transactions/transfers, restores the last-selected transfer-totals option (and clears it when none exist), and updates the transfer totals panel sorting/labels. Added PrefManager keys and helper methods for storing/getting/clearing last-add transaction envelope, per-source last transfer destination, and last transfer-totals option key.